### PR TITLE
Support Gulp v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To use this Gulp configuration file, once you have downloaded the framework, mak
 
 ```
 npm install
-gulp watch
+npm run gulp watch
 ```
 
 The first command will install the modules the framework requires for compiling SCSS into CSS; the second will launch your project on a development server.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,16 +16,17 @@ gulp.task('sass', function() {
   }));
 });
 
-gulp.task('browserSync', function() {
+gulp.task('browserSync', gulp.series(function (done) {
   browserSync.init({
     server: {
       baseDir: 'main'
     },
   })
-});
+  done();
+}));
 
 gulp.task('watch', gulp.series(['browserSync', 'sass'], function () {
-  gulp.watch('main/assets/css/**/*.scss', ['sass']);
+  gulp.watch('main/assets/css/**/*.scss', gulp.series(['sass']));
   gulp.watch('main/*.html', browserSync.reload);
   gulp.watch('main/demo/*.html', browserSync.reload); 
   gulp.watch('main/assets/js/**/*.js', browserSync.reload);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,9 +24,9 @@ gulp.task('browserSync', function() {
   })
 });
 
-gulp.task('watch', ['browserSync', 'sass'], function (){
+gulp.task('watch', gulp.series(['browserSync', 'sass'], function () {
   gulp.watch('main/assets/css/**/*.scss', ['sass']);
   gulp.watch('main/*.html', browserSync.reload);
   gulp.watch('main/demo/*.html', browserSync.reload); 
   gulp.watch('main/assets/js/**/*.js', browserSync.reload);
-});
+}));

--- a/package.json
+++ b/package.json
@@ -4,17 +4,18 @@
   "description": "The CodyHouse's framework is a system of SCSS globals representing the base upon which you can build the style of your web project.",
   "main": "index.js",
   "scripts": {
+    "gulp": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Amber Creative Lab <info@ambercreative.co>",
   "license": "MIT",
   "browserslist": "last 2 versions, > 5%, ie 9-11",
   "devDependencies": {
-    "autoprefixer": "^8.2.0",
-    "browser-sync": "^2.23.6",
-    "gulp": "^3.9.1",
-    "gulp-postcss": "^7.0.1",
-    "gulp-sass": "^3.2.1",
+    "autoprefixer": "^9.4.3",
+    "browser-sync": "^2.26.3",
+    "gulp": "^4.0.0",
+    "gulp-postcss": "^8.0.0",
+    "gulp-sass": "^4.0.2",
     "postcss-calc": "^7.0.1",
     "postcss-css-variables": "git+https://github.com/CodyHouse/postcss-css-variables"
   }


### PR DESCRIPTION
I've really liked the CodyHouse experiments, so I'm excited to start using the framework
If you're interested, I migrated to Gulp v4 and updated other dependencies. I added a script so that you can use `npm run gulp watch` rather than a globally installed gulp; tested on Windows and Mac