### PR TITLE
fix round-with mixin

### DIFF
--- a/main/assets/css/global/_grid-layout.scss
+++ b/main/assets/css/global/_grid-layout.scss
@@ -176,8 +176,8 @@ $grid-columns: 12;
 
 @function round-width ($i) {
   //function used to round width to a number with 2 decimal places - used for IE fallback
-  $width : floor(100 * $i * 100/ $grid-columns) / 100;
-  @return $width#{"%"};
+  $width : floor(100% * $i * 100%/ $grid-columns) / 100%;
+  @return $width;
 }
 
 @mixin autoSizedColumn {

--- a/main/assets/css/global/_grid-layout.scss
+++ b/main/assets/css/global/_grid-layout.scss
@@ -176,7 +176,7 @@ $grid-columns: 12;
 
 @function round-width ($i) {
   //function used to round width to a number with 2 decimal places - used for IE fallback
-  $width : floor(100% * $i * 100%/ $grid-columns) / 100%;
+  $width : floor(100% * $i * 100/ $grid-columns) / 100;
   @return $width;
 }
 


### PR DESCRIPTION
`round-with` mixin generates space between value and unit.

For example: 

    .col--lg-3 {
        flex-basis: 25 %;
        max-width: 25 %;
    }

And this is not working in browser!

I fixed this.