### PR TITLE
Remove document write

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,17 @@ Besides checking JavaScript support, we check the support of CSS custom properti
 
 ```html
 <script>
+  function addCss(path) {
+    var link = document.createElement('link');
+    link.type = 'text/css';
+    link.rel = 'stylesheet';
+    link.href = path;
+    document.head.appendChild(link);
+  }
   if('CSS' in window && CSS.supports('color', 'var(--color-var)')) {
-    document.write('<link rel="stylesheet" href="assets/css/style.css">');
+    addCss('assets/css/style.css');
   } else {
-    document.write('<link rel="stylesheet" href="assets/css/style-fallback.css">');
+    addCss('assets/css/style-fallback.css');
   }
 </script>
 <noscript>

--- a/main/index.html
+++ b/main/index.html
@@ -5,10 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>document.getElementsByTagName("html")[0].className += " js";</script>
   <script>
+    function addCss(path) {
+      var link = document.createElement('link');
+      link.type = 'text/css';
+      link.rel = 'stylesheet';
+      link.href = path;
+      document.head.appendChild(link);
+    }
     if('CSS' in window && CSS.supports('color', 'var(--color-var)')) {
-      document.write('<link rel="stylesheet" href="assets/css/style.css">');
+      addCss('assets/css/style.css');
     } else {
-      document.write('<link rel="stylesheet" href="assets/css/style-fallback.css">');
+      addCss('assets/css/style-fallback.css');
     }
   </script>
   <noscript>


### PR DESCRIPTION
As of Chrome 55, pages containing a `document.write` script [will not execute it on slower connections](https://developers.google.com/web/updates/2016/08/removing-document-write). Google's Lighthouse auditing tool even has a [warning against it](https://developers.google.com/web/tools/lighthouse/audits/document-write). The MDN docs also [warn against using it](https://developer.mozilla.org/en-US/docs/Web/API/Document/write).

This PR replaces the index page's `document.write` script with the recommended way of writing an element to the DOM. There is a shared function included to avoid unnecessarily repetitious code.