### PR TITLE
Added aspect ratios

### DIFF
--- a/main/assets/css/base/_util.scss
+++ b/main/assets/css/base/_util.scss
@@ -661,8 +661,20 @@
   }
 }
 
-.media-wrapper--4\:3 {
-  padding-bottom: 75%; // 4:3
+$media-wrapper-aspect-ratios: (
+  (21 9),
+  (16 9), // default for .media-wrapper
+  (4 3),
+  (1 1)
+);
+
+@each $aspect-ratio in $media-wrapper-aspect-ratios {
+  $aspect-ratio-x: nth($aspect-ratio, 1);
+  $aspect-ratio-y: nth($aspect-ratio, 2);
+
+  .media-wrapper--#{$aspect-ratio-x}\:#{$aspect-ratio-y} {
+    padding-bottom: calc((#{$aspect-ratio-y} / #{$aspect-ratio-x}) * 100%);
+  }
 }
 
 // --------------------------------


### PR DESCRIPTION
Added a Sass list of aspect ratios. This list is iterated over to generate utility classes for each.

This is takes inspiration from the way Bootstrap generates aspect ratio classes, with one difference. Instead of using the Sass `percentage()` function, I'm using `calc()` directly. [Browser support is good](https://caniuse.com/#feat=calc); thanks to the `postcss-calc` plugin, the fallback stylesheet outputs the percentages directly.