### PR TITLE
Update _util.scss with Flex no wrap

### DIFF
--- a/main/assets/css/base/_util.scss
+++ b/main/assets/css/base/_util.scss
@@ -8,6 +8,7 @@
   .flex { display: flex; }
   .inline-flex { display: inline-flex; }
   .flex-wrap { flex-wrap: wrap; }
+  .flex-nowrap {flex-wrap: nowrap;}
   .flex-column { flex-direction: column; }
   .flex-column-reverse { flex-direction: column-reverse; }
   .flex-row { flex-direction: row; }
@@ -1308,6 +1309,7 @@
       .flex\@#{$breakpoint} { display: flex; }
       .inline-flex\@#{$breakpoint} { display: inline-flex; }
       .flex-wrap\@#{$breakpoint} { flex-wrap: wrap; }
+      .flex-nowrap\@#{$breakpoint} {flex-wrap:nowrap;}
       .flex-column\@#{$breakpoint} { flex-direction: column; }
       .flex-column-reverse\@#{$breakpoint} { flex-direction: column-reverse; }
       .flex-row\@#{$breakpoint} { flex-direction: row; }


### PR DESCRIPTION
This will be useful for building layout. For example, the "Flex-nowrap" property can play a key role in manipulating and changing a navigation bar layout without moving the actual markup around.